### PR TITLE
Fix Infinite Loop within extractData

### DIFF
--- a/Sources/MultipartFormDataParser/MultipartFormDataParser.swift
+++ b/Sources/MultipartFormDataParser/MultipartFormDataParser.swift
@@ -23,6 +23,9 @@ private extension MultipartFormDataParser {
         while stream.hasBytesAvailable {
             var buffer = [UInt8](repeating: 0, count: 512)
             let count = stream.read(&buffer, maxLength: buffer.count)
+            if count <= 0 {
+                break
+            }
             data.append(buffer, count: count)
         }
         return data


### PR DESCRIPTION
* Fix infinite loop by verifying `InputStream.read` result