### PR TITLE
Bump swift-tools-version to 5.5

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -10,7 +10,7 @@ jobs:
     name: Danger
     runs-on: ubuntu-18.04
     concurrency: 
-      group: ${{ github.head_ref }}
+      group: ${{ github.head_ref }}-${{ github.workflow }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -9,6 +9,9 @@ jobs:
   danger:
     name: Danger
     runs-on: ubuntu-18.04
+    concurrency: 
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
       - name: Danger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        xcode: [13.2.1]
+        xcode: ['13.2.1']
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test
     runs-on: macos-11
     concurrency: 
-      group: ${{ github.head_ref }}
+      group: ${{ github.head_ref }}-${{ github.workflow }}-${{ matrix.xcode }}-${{ matrix.destination }}
       cancel-in-progress: true
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,12 @@ on:
       - Sources/**/*.swift
       - Tests/**/*.swift
 jobs:
-  big_sur:
-    name: Big Sur
+  test:
+    name: Test
     runs-on: macos-11
+    concurrency: 
+      group: ${{ github.head_ref }}
+      cancel-in-progress: true
     strategy:
       matrix:
         xcode: ['13.0', '13.1', '13.2.1']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
           - "platform=macOS,variant=Mac Catalyst"
           - "platform=iOS Simulator,name=iPhone 12 Pro"
           - "platform=tvOS Simulator,name=Apple TV 4K"
+      fail-fast: false
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        xcode: [12.4, 12.5.1, 13.2.1]
+        xcode: [13.0, 13.1, 13.2.1]
         destination: 
           - "platform=macOS"
           - "platform=macOS,variant=Mac Catalyst"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        xcode: [13.0, 13.1, 13.2.1]
+        xcode: ['13.0', '13.1', '13.2.1']
         destination: 
           - "platform=macOS"
           - "platform=macOS,variant=Mac Catalyst"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -8,9 +8,9 @@ let isRelease = false
 let testDependencies: [Package.Dependency] = isRelease
 ? []
 : [
-    .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.4.4"),
+    .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.5.0"),
     .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
-    .package(url: "https://github.com/ishkawa/APIKit.git", from: "5.2.0"),
+    .package(url: "https://github.com/ishkawa/APIKit.git", from: "5.3.0"),
     .package(url: "https://github.com/Moya/Moya.git", from: "15.0.0"),
 ]
 let testTargetDependencies: [Target.Dependency] = isRelease

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let testTargetDependencies: [Target.Dependency] = isRelease
     "Alamofire",
     "APIKit",
     "Moya",
-    "OHHTTPStubsSwift",
+    .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
 ]
 
 let package = Package(


### PR DESCRIPTION
Xcode 13 will be required for iOS/iPadOS apps since April 25.
https://developer.apple.com/news/?id=2t1chhp3&1647378082

It means that Swift 5.5 will be required.
https://qiita.com/uhooi/items/b16c0959aa6e3caf5426