### PR TITLE
Enable test without `OHHTTPStubs`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let testDependencies: [Package.Dependency] = isRelease
 ? []
 : [
     .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.6.0"),
-    .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
+    // .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", from: "9.1.0"),
     .package(url: "https://github.com/ishkawa/APIKit.git", from: "5.3.0"),
     .package(url: "https://github.com/Moya/Moya.git", from: "15.0.0"),
 ]
@@ -19,7 +19,7 @@ let testTargetDependencies: [Target.Dependency] = isRelease
     "Alamofire",
     "APIKit",
     "Moya",
-    .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
+    // .product(name: "OHHTTPStubsSwift", package: "OHHTTPStubs"),
 ]
 
 let package = Package(

--- a/Tests/MultipartFormDataParserTests/MultipartFormDataTestUtil_CocoaTests.swift
+++ b/Tests/MultipartFormDataParserTests/MultipartFormDataTestUtil_CocoaTests.swift
@@ -84,7 +84,6 @@ final class MultipartFormDataParser_CocoaTests: XCTestCase {
     }
     #endif
 
-    #if canImport(OHHTTPStubs)
     func testURLSessionDataTask() throws {
         let genbaNeko = try XCTUnwrap(NSImage(data: TestResource.genbaNeko)?.jpegRepresentation)
         let denwaNeko = try XCTUnwrap(NSImage(data: TestResource.denwaNeko)?.jpegRepresentation)
@@ -102,6 +101,5 @@ final class MultipartFormDataParser_CocoaTests: XCTestCase {
         XCTAssertEqual(result.status, 200)
         XCTAssertNil(result.error)
     }
-    #endif
 }
 #endif

--- a/Tests/MultipartFormDataParserTests/MultipartFormDataTestUtil_UIKitTests.swift
+++ b/Tests/MultipartFormDataParserTests/MultipartFormDataTestUtil_UIKitTests.swift
@@ -85,7 +85,6 @@ final class MultipartFormDataParser_UIKitTests: XCTestCase {
     }
     #endif
 
-    #if canImport(OHHTTPStubs)
     func testURLSessionUploadTask() throws {
         let genbaNeko = try XCTUnwrap(UIImage(data: TestResource.genbaNeko)?.jpegData(compressionQuality: 1))
         let denwaNeko = try XCTUnwrap(UIImage(data: TestResource.denwaNeko)?.jpegData(compressionQuality: 1))
@@ -103,6 +102,5 @@ final class MultipartFormDataParser_UIKitTests: XCTestCase {
         XCTAssertEqual(result.status, 200)
         XCTAssertNil(result.error)
     }
-    #endif
 }
 #endif

--- a/Tests/MultipartFormDataParserTests/StubURLProtocol.swift
+++ b/Tests/MultipartFormDataParserTests/StubURLProtocol.swift
@@ -1,0 +1,38 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+final class StubURLProtocol: URLProtocol {
+    typealias RequestHandler = (URLRequest) throws -> (Data?, HTTPURLResponse)
+
+    static var requestHandler: RequestHandler?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let requestHandler = Self.requestHandler else { return }
+        do {
+            let (data, response) = try requestHandler(request)
+            client?.urlProtocol(self,
+                                didReceive: response,
+                                cacheStoragePolicy: .notAllowed)
+            if let data = data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {
+        // no-op
+    }
+}

--- a/Tests/MultipartFormDataParserTests/TestFunctions/TestFunction_APIKit.swift
+++ b/Tests/MultipartFormDataParserTests/TestFunctions/TestFunction_APIKit.swift
@@ -4,6 +4,17 @@ import XCTest
 #if canImport(APIKit)
 import APIKit
 
+private let session: Session = {
+    #if canImport(OHHTTPStubs)
+    return .shared
+    #else
+    let configuration = URLSessionConfiguration.default
+    configuration.protocolClasses = [StubURLProtocol.self]
+    let adapter = URLSessionAdapter(configuration: configuration)
+    return Session(adapter: adapter)
+    #endif
+}()
+
 extension XCTestCase {
     func requestWithAPIKit(
         genbaNeko: Data,
@@ -37,7 +48,7 @@ extension XCTestCase {
             line: line
         )
         var result: Result<TestRequest.Response, SessionTaskError>!
-        Session.shared.send(request, callbackQueue: nil) {
+        session.send(request, callbackQueue: nil) {
             result = $0
             exp.fulfill()
         }

--- a/Tests/MultipartFormDataParserTests/TestFunctions/TestFunction_Alamofire.swift
+++ b/Tests/MultipartFormDataParserTests/TestFunctions/TestFunction_Alamofire.swift
@@ -4,6 +4,16 @@ import XCTest
 #if canImport(Alamofire)
 import Alamofire
 
+private let session: Session = {
+    #if canImport(OHHTTPStubs)
+    return AF
+    #else
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [StubURLProtocol.self]
+    return Session(configuration: configuration)
+    #endif
+}()
+
 extension XCTestCase {
     func uploadWithAlamoFire(
         genbaNeko: Data,
@@ -14,7 +24,7 @@ extension XCTestCase {
         line: UInt = #line
     ) throws -> TestEntity? {
         let exp = expectation(description: "response")
-        let task = AF.upload(
+        let task = session.upload(
             multipartFormData: { formData in
                 formData.append(
                     genbaNeko,
@@ -63,7 +73,7 @@ extension XCTestCase {
     ) async throws -> TestEntity {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return try await AF.upload(
+        return try await session.upload(
             multipartFormData: { formData in
                 formData.append(
                     genbaNeko,

--- a/Tests/MultipartFormDataParserTests/TestFunctions/TestFunction_Moya.swift
+++ b/Tests/MultipartFormDataParserTests/TestFunctions/TestFunction_Moya.swift
@@ -4,6 +4,16 @@ import XCTest
 #if canImport(Moya)
 import Moya
 
+private let provider: MoyaProvider<TestTarget> = {
+    #if canImport(OHHTTPStubs)
+    return MoyaProvider()
+    #else
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [StubURLProtocol.self]
+    return MoyaProvider(session: Session(configuration: configuration))
+    #endif
+}()
+
 extension XCTestCase {
     func uploadWithMoya(
         genbaNeko: Data,
@@ -23,7 +33,7 @@ extension XCTestCase {
             line: line
         )
         var result: Result<Response, MoyaError>!
-        MoyaProvider().request(target) {
+        provider.request(target) {
             result = $0
             exp.fulfill()
         }

--- a/Tests/MultipartFormDataParserTests/TestFunctions/TestFunction_URLSession.swift
+++ b/Tests/MultipartFormDataParserTests/TestFunctions/TestFunction_URLSession.swift
@@ -1,6 +1,16 @@
 import Foundation
 import XCTest
 
+private let session: URLSession = {
+    #if canImport(OHHTTPStubs)
+    return .shared
+    #else
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: configuration)
+    #endif
+}()
+
 extension XCTestCase {
     func uploadURLSessionDataTask(
         genbaNeko: Data,
@@ -14,13 +24,16 @@ extension XCTestCase {
 
         let request = createRequest(genbaNeko: genbaNeko, denwaNeko: denwaNeko, message: message)
         var responseData: Data!
-        URLSession.shared.dataTask(with: request) { data, _, _ in
+        session.dataTask(with: request) { data, _, _ in
             responseData = data
             exp.fulfill()
         }.resume()
         waitForExpectations(timeout: timeoutInterval)
 
         guard let data = responseData else {
+            guard retryCount > 0 else {
+                throw URLError(.fileDoesNotExist)
+            }
             return try uploadURLSessionDataTask(genbaNeko: genbaNeko,
                                                 denwaNeko: denwaNeko,
                                                 message: message,
@@ -51,12 +64,15 @@ extension XCTestCase {
                                      denwaNeko: denwaNeko,
                                      message: message)
         var responseData: Data!
-        URLSession.shared.uploadTask(with: request, from: requestBody) { data, _, _ in
+        session.uploadTask(with: request, from: requestBody) { data, _, _ in
             responseData = data
             exp.fulfill()
         }.resume()
         waitForExpectations(timeout: timeoutInterval)
         guard let data = responseData else {
+            guard retryCount > 0 else {
+                throw URLError(.fileDoesNotExist)
+            }
             return try uploadURLSessionUploadTask(genbaNeko: genbaNeko,
                                                   denwaNeko: denwaNeko,
                                                   message: message,

--- a/Tests/MultipartFormDataParserTests/TestFunctions/TestFunction_URLSession.swift
+++ b/Tests/MultipartFormDataParserTests/TestFunctions/TestFunction_URLSession.swift
@@ -1,7 +1,6 @@
 import Foundation
 import XCTest
 
-#if canImport(OHHTTPStubs)
 extension XCTestCase {
     func uploadURLSessionDataTask(
         genbaNeko: Data,
@@ -68,7 +67,6 @@ extension XCTestCase {
         return try JSONDecoder().decode(TestEntity.self, from: data)
     }
 }
-#endif
 
 extension XCTestCase {
     func createRequest(

--- a/Tests/MultipartFormDataParserTests/TestStub.swift
+++ b/Tests/MultipartFormDataParserTests/TestStub.swift
@@ -1,3 +1,8 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 #if canImport(Cocoa) && !targetEnvironment(macCatalyst)
 import Cocoa
 typealias Image = NSImage
@@ -20,17 +25,22 @@ func stubForUpload() {
     let condition = isHost("localhost")
         && isPath("/upload")
     stub(condition: condition, response: uploadTestStubResponse)
+    #else
+    StubURLProtocol.requestHandler = uploadTestStubResponse
+    URLProtocol.registerClass(StubURLProtocol.self)
     #endif
 }
 
 func clearStubs() {
     #if canImport(OHHTTPStubs)
     HTTPStubs.removeAllStubs()
+    #else
+    URLProtocol.unregisterClass(StubURLProtocol.self)
     #endif
 }
 
 #if canImport(OHHTTPStubs)
-private var uploadTestStubResponse: HTTPStubsResponseBlock = { request in
+private let uploadTestStubResponse: HTTPStubsResponseBlock = { request in
     let errorResponse = { (message: String) -> HTTPStubsResponse in
         .init(jsonObject: ["status": 403, "error": message], statusCode: 403, headers: ["Content-Type": "application/json"])
     }
@@ -50,5 +60,35 @@ private var uploadTestStubResponse: HTTPStubsResponseBlock = { request in
         statusCode: 200,
         headers: ["Content-Type": "application/json"]
     )
+}
+#else
+private let uploadTestStubResponse: StubURLProtocol.RequestHandler = { request in
+    let errorResponse = { (message: String) -> (Data?, HTTPURLResponse) in
+        (
+            #"{"status": 403, "error": "\#(message)"}"#.data(using: .utf8),
+            HTTPURLResponse(url: request.url!,
+                            statusCode: 403,
+                            httpVersion: "HTTP/2",
+                            headerFields: ["Content-Type": "application/json"])!
+        )
+    }
+    do {
+        let data = try MultipartFormData.parse(from: request)
+        guard let genbaNeko = data.element(forName: "genbaNeko") else { return errorResponse("genbaNeko") }
+        guard let denwaNeko = data.element(forName: "denwaNeko") else { return errorResponse("denwaNeko") }
+        guard let message = data.element(forName: "message") else { return errorResponse("message") }
+        guard let _ = Image(data: genbaNeko.data) else { return errorResponse("Unexpected genbaNeko") }
+        guard let _ = Image(data: denwaNeko.data) else { return errorResponse("Unexpected denwaNeko") }
+        guard message.string == "Hello world!" else { return errorResponse("Unexpected message: \(message)") }
+        return (
+            #"{"status": 200}"#.data(using: .utf8),
+            HTTPURLResponse(url: request.url!,
+                            statusCode: 200,
+                            httpVersion: "HTTP/2",
+                            headerFields: ["Content-Type": "application/json"])!
+        )
+    } catch {
+        return errorResponse(error.localizedDescription)
+    }
 }
 #endif

--- a/Tests/MultipartFormDataParserTests/TestStub.swift
+++ b/Tests/MultipartFormDataParserTests/TestStub.swift
@@ -27,15 +27,12 @@ func stubForUpload() {
     stub(condition: condition, response: uploadTestStubResponse)
     #else
     StubURLProtocol.requestHandler = uploadTestStubResponse
-    URLProtocol.registerClass(StubURLProtocol.self)
     #endif
 }
 
 func clearStubs() {
     #if canImport(OHHTTPStubs)
     HTTPStubs.removeAllStubs()
-    #else
-    URLProtocol.unregisterClass(StubURLProtocol.self)
     #endif
 }
 


### PR DESCRIPTION
- create stub for `URLProtocol`
- add stub response
- enable testing with URLSession without `OHHTTPStubs`
- enable testing with `APIKit` without `OHHTTPStubs`
- fix `URLSession` test
- enable testing with `Alamofire` without `OHHTTPStubs`
- enable testing with `Moya` without `OHHTTPStubs`
